### PR TITLE
FEATURE: Add a test to check the result of a sub command

### DIFF
--- a/Classes/Test/SubCommandTest.php
+++ b/Classes/Test/SubCommandTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace t3n\Flow\HealthStatus\Test;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Configuration\Exception\InvalidConfigurationException;
+use Neos\Flow\Core\Booting\Scripts;
+use Neos\Flow\Utility\Environment;
+
+/**
+ * This file is part of the t3n.Flow.HealthStatus package.
+ *
+ * (c) 2018 yeebase media GmbH
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+class SubCommandTest extends AbstractTest
+{
+    /**
+     * @Flow\Inject
+     *
+     * @var Environment
+     */
+    protected $environment;
+
+    /**
+     * @Flow\InjectConfiguration(package="Neos.Flow", path="core.phpBinaryPathAndFilename")
+     *
+     * @var string
+     */
+    protected $phpBinaryPathAndFilename;
+
+    /**
+     * @param mixed[] $options
+     *
+     * @throws InvalidConfigurationException
+     */
+    protected function validateOptions(array $options): void
+    {
+        if (!isset($options['commandIdentifier'])) {
+            throw new InvalidConfigurationException('The command identifier of the sub-command to execute must be provided', 1596028979);
+        }
+    }
+
+    /**
+     * @throws \Neos\Flow\Core\Booting\Exception\SubProcessException
+     */
+    public function test(): bool
+    {
+        return $this->dispatchCommand(
+            $this->options['commandIdentifier'],
+            $this->options['commandArguments'] ?? [],
+            $this->options['commandContext'] ?? ''
+        );
+    }
+
+    /**
+     * @param string $commandIdentifier the identifier of the flow command
+     * @param string[] $commandArguments
+     * @param string $commandContext the context the sub command runs in
+     *
+     * @throws \Neos\Flow\Core\Booting\Exception\SubProcessException
+     */
+    private function dispatchCommand(string $commandIdentifier, array $commandArguments = [], string $commandContext = ''): bool
+    {
+        $settings['core']['context'] = $commandContext === '' ? $this->environment->getContext() : $commandContext;
+        $settings['core']['phpBinaryPathAndFilename'] = $this->phpBinaryPathAndFilename;
+
+        return Scripts::executeCommand($commandIdentifier, $settings, true, $commandArguments);
+    }
+}

--- a/Classes/Test/SubCommandTest.php
+++ b/Classes/Test/SubCommandTest.php
@@ -8,7 +8,6 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Configuration\Exception\InvalidConfigurationException;
 use Neos\Flow\Core\Booting\Exception\SubProcessException;
 use Neos\Flow\Core\Booting\Scripts;
-use Neos\Flow\Utility\Environment;
 
 /**
  * This file is part of the t3n.Flow.HealthStatus package.
@@ -21,13 +20,6 @@ use Neos\Flow\Utility\Environment;
  */
 class SubCommandTest extends AbstractTest
 {
-    /**
-     * @Flow\Inject
-     *
-     * @var Environment
-     */
-    protected $environment;
-
     /**
      * @Flow\InjectConfiguration(package="Neos.Flow")
      *
@@ -68,7 +60,9 @@ class SubCommandTest extends AbstractTest
      */
     private function dispatchCommand(string $commandIdentifier, array $commandArguments = [], string $commandContext = ''): bool
     {
-        $this->flowSettings['core']['context'] = $commandContext === '' ? $this->environment->getContext() : $commandContext;
+        if (! empty($commandContext)) {
+            $this->flowSettings['core']['context'] = $commandContext;
+        }
 
         return Scripts::executeCommand($commandIdentifier, $this->flowSettings, true, $commandArguments);
     }

--- a/Classes/Test/SubCommandTest.php
+++ b/Classes/Test/SubCommandTest.php
@@ -35,13 +35,20 @@ class SubCommandTest extends AbstractTest
     protected $phpBinaryPathAndFilename;
 
     /**
+     * @Flow\InjectConfiguration(package="Neos.Flow")
+     *
+     * @var string[][]
+     */
+    protected $flowSettings;
+
+    /**
      * @param mixed[] $options
      *
      * @throws InvalidConfigurationException
      */
     protected function validateOptions(array $options): void
     {
-        if (!isset($options['commandIdentifier'])) {
+        if (! isset($options['commandIdentifier'])) {
             throw new InvalidConfigurationException('The command identifier of the sub-command to execute must be provided', 1596028979);
         }
     }
@@ -67,9 +74,9 @@ class SubCommandTest extends AbstractTest
      */
     private function dispatchCommand(string $commandIdentifier, array $commandArguments = [], string $commandContext = ''): bool
     {
-        $settings['core']['context'] = $commandContext === '' ? $this->environment->getContext() : $commandContext;
-        $settings['core']['phpBinaryPathAndFilename'] = $this->phpBinaryPathAndFilename;
+        $this->flowSettings['core']['context'] = $commandContext === '' ? $this->environment->getContext() : $commandContext;
+        $this->flowSettings['core']['phpBinaryPathAndFilename'] = $this->phpBinaryPathAndFilename;
 
-        return Scripts::executeCommand($commandIdentifier, $settings, true, $commandArguments);
+        return Scripts::executeCommand($commandIdentifier, $this->flowSettings, true, $commandArguments);
     }
 }

--- a/Classes/Test/SubCommandTest.php
+++ b/Classes/Test/SubCommandTest.php
@@ -6,6 +6,7 @@ namespace t3n\Flow\HealthStatus\Test;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Configuration\Exception\InvalidConfigurationException;
+use Neos\Flow\Core\Booting\Exception\SubProcessException;
 use Neos\Flow\Core\Booting\Scripts;
 use Neos\Flow\Utility\Environment;
 
@@ -28,13 +29,6 @@ class SubCommandTest extends AbstractTest
     protected $environment;
 
     /**
-     * @Flow\InjectConfiguration(package="Neos.Flow", path="core.phpBinaryPathAndFilename")
-     *
-     * @var string
-     */
-    protected $phpBinaryPathAndFilename;
-
-    /**
      * @Flow\InjectConfiguration(package="Neos.Flow")
      *
      * @var string[][]
@@ -54,7 +48,7 @@ class SubCommandTest extends AbstractTest
     }
 
     /**
-     * @throws \Neos\Flow\Core\Booting\Exception\SubProcessException
+     * @throws SubProcessException
      */
     public function test(): bool
     {
@@ -70,12 +64,11 @@ class SubCommandTest extends AbstractTest
      * @param string[] $commandArguments
      * @param string $commandContext the context the sub command runs in
      *
-     * @throws \Neos\Flow\Core\Booting\Exception\SubProcessException
+     * @throws SubProcessException
      */
     private function dispatchCommand(string $commandIdentifier, array $commandArguments = [], string $commandContext = ''): bool
     {
         $this->flowSettings['core']['context'] = $commandContext === '' ? $this->environment->getContext() : $commandContext;
-        $this->flowSettings['core']['phpBinaryPathAndFilename'] = $this->phpBinaryPathAndFilename;
 
         return Scripts::executeCommand($commandIdentifier, $this->flowSettings, true, $commandArguments);
     }


### PR DESCRIPTION
This can be used for example to check the S3 connection when using the
flownative s3 adapter (https://github.com/flownative/flow-aws-s3)

example:
```
t3n:
  Flow:
    HealthStatus:
      livenessChain:
        s3:
          test: t3n\Flow\HealthStatus\Test\SubCommandTest
          options:
            commandIdentifier: 's3:connect'
```