### PR TITLE
BUGFIX: Make sure to mute subcommand output

### DIFF
--- a/Classes/Test/SubCommandTest.php
+++ b/Classes/Test/SubCommandTest.php
@@ -64,6 +64,9 @@ class SubCommandTest extends AbstractTest
             $this->flowSettings['core']['context'] = $commandContext;
         }
 
-        return Scripts::executeCommand($commandIdentifier, $this->flowSettings, true, $commandArguments);
+        ob_start();
+        $result =  Scripts::executeCommand($commandIdentifier, $this->flowSettings, true, $commandArguments);
+        ob_clean();
+        return $result;
     }
 }


### PR DESCRIPTION
Direct outputs of a subcommand will be passed to the main process and then 
output directly. This breaks the output of a probe call via http as it is sent before the headers.