### PR TITLE
Add missing use of $errors in anonymous function

### DIFF
--- a/Classes/Controller/HealthStatusController.php
+++ b/Classes/Controller/HealthStatusController.php
@@ -42,7 +42,7 @@ class HealthStatusController extends ActionController
             }
         });
 
-        $taskRunner->onTaskResult(static function (TaskInterface $task, Result $result) use (&$success): void {
+        $taskRunner->onTaskResult(static function (TaskInterface $task, Result $result) use (&$errors, &$success): void {
             if ($result->hasErrors()) {
                 $errors[] = [
                     'name' => $task->getName(),


### PR DESCRIPTION
The variable is populated inside the function, but the result was never
passed back to the "outside world."